### PR TITLE
chore: add nolint funlen

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,8 +13,14 @@ jobs:
     name: Lint the source code
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44
+          version: v1.45
+          args: --timeout 10m
+          # only-new-issues: true

--- a/protoc-gen-ship/eventify.go
+++ b/protoc-gen-ship/eventify.go
@@ -105,7 +105,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-// nolint:gochecknoinits
+// nolint:gochecknoinits,funlen
 func init() {
 {{ range .AllMessages -}}
 	ship.RegisterEvent(&{{ name . }}{})


### PR DESCRIPTION
## Description

Adds nolint funlen flag to `init` function.
As the no. of events increases, the `linter` will start throwing error.

To solve the issue, we are adding `nolint:funlen`.
Although, adding comment with `DO NOT EDIT` could solve the problem. But, having a proper checks for now would create a stable library.

## Type of change

- [x] Chore 

## How have you tested this code?

Does not require test.


## Checklist:

- [x] My code follows the proper style guideline
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
