### PR TITLE
fix: use proto name for json marshalling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ example: protoc-gen-go bin/protoc-gen-ship
 protoc-gen-go:
 	which protoc-gen-go || (go install github.com/golang/protobuf/protoc-gen-go)
 
+.PHONY: bin/*
 bin/protoc-gen-ship:
 	go build -o ./bin/protoc-gen-ship ./protoc-gen-ship
 

--- a/protoc-gen-ship/eventify.go
+++ b/protoc-gen-ship/eventify.go
@@ -121,7 +121,7 @@ func (m *{{ name . }}) EventName() string {
 
 // {{ marshaler . }} describes the default jsonpb.Marshaler used by all 
 // instances of {{ name . }}.
-var {{ marshaler . }} = new(protojson.MarshalOptions)
+var {{ marshaler . }} = &protojson.MarshalOptions{UseProtoNames: true}
 
 // MarshalJSON satisfies the encoding/json Marshaler interface. This method 
 // uses the more correct jsonpb package to correctly marshal the message.


### PR DESCRIPTION
## Description

Adds configuration to use proto field names in json.

Earlier `created_at` would become `createdAt` if marshalled to json.

Changelog:
- chore: generate binary each time
- fix: use proto names in json


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
 
## How have you tested this code?

Code has been tested with other projects to validate that nothing has changed.

## Checklist:

- [x] My code follows the proper style guideline
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
