### PR TITLE
feat: use unused fields in protojson

### DIFF
--- a/protoc-gen-ship/eventify.go
+++ b/protoc-gen-ship/eventify.go
@@ -121,7 +121,10 @@ func (m *{{ name . }}) EventName() string {
 
 // {{ marshaler . }} describes the default jsonpb.Marshaler used by all 
 // instances of {{ name . }}.
-var {{ marshaler . }} = &protojson.MarshalOptions{UseProtoNames: true}
+var {{ marshaler . }} = &protojson.MarshalOptions{
+	UseProtoNames: true,
+	EmitUnpopulated: true,
+}
 
 // MarshalJSON satisfies the encoding/json Marshaler interface. This method 
 // uses the more correct jsonpb package to correctly marshal the message.


### PR DESCRIPTION
## Description

`protojson` removes the empty fields while marshalling to `json`.
We require some those fields as they represent some meaning in our system.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How have you tested this code?

All test passes.

## Checklist:

- [x] My code follows the proper style guideline
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
