### PR TITLE
refactor: dont fail on ummarshalling for missing fields

### DIFF
--- a/protoc-gen-ship/eventify.go
+++ b/protoc-gen-ship/eventify.go
@@ -124,6 +124,7 @@ func (m *{{ name . }}) EventName() string {
 var {{ marshaler . }} = &protojson.MarshalOptions{
 	UseProtoNames: true,
 	EmitUnpopulated: true,
+	AllowPartial: true,
 }
 
 // MarshalJSON satisfies the encoding/json Marshaler interface. This method 
@@ -140,7 +141,9 @@ var _ json.Marshaler = (*{{ name . }})(nil)
 
 // {{ unmarshaler . }} describes the default jsonpb.Unmarshaler used by all 
 // instances of {{ name . }}.
-var {{ unmarshaler . }} = new(protojson.UnmarshalOptions)
+var {{ unmarshaler . }} = &protojson.UnmarshalOptions{
+	AllowPartial: true,
+}
 
 // UnmarshalJSON satisfies the encoding/json Unmarshaler interface. This method 
 // uses the more correct jsonpb package to correctly unmarshal the message.


### PR DESCRIPTION
## Description

When a field is missing or unknown. The unmarshalling fails as we use protojson to marshal and unmarshal.

This pull request will allow partial data to be marshalled.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How have you tested this code?

All the tests passes.

## Checklist:

- [x] My code follows the proper style guideline
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
