### PR TITLE
fix: ignore unknonw fields in unmarshalling

### DIFF
--- a/protoc-gen-ship/eventify.go
+++ b/protoc-gen-ship/eventify.go
@@ -142,7 +142,8 @@ var _ json.Marshaler = (*{{ name . }})(nil)
 // {{ unmarshaler . }} describes the default jsonpb.Unmarshaler used by all 
 // instances of {{ name . }}.
 var {{ unmarshaler . }} = &protojson.UnmarshalOptions{
-	AllowPartial: true,
+	AllowPartial:   true,
+	DiscardUnknown: true,
 }
 
 // UnmarshalJSON satisfies the encoding/json Unmarshaler interface. This method 


### PR DESCRIPTION
## Description

A field addition in proto definition breaks the unmarshalling for other services.
We want to maintain backward compatibility so, we are ignoring the new fields in marshalling.

NOTE: This doesn't happens if we are using the default golang `json` package.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the proper style guideline
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
